### PR TITLE
WirelessTag ZX7981POEQ - Fixes for leds configuration

### DIFF
--- a/package/boot/uboot-mediatek/patches/474-add-zx7981poeq.patch
+++ b/package/boot/uboot-mediatek/patches/474-add-zx7981poeq.patch
@@ -143,7 +143,7 @@
 +CONFIG_LMB_MAX_REGIONS=64
 +--- /dev/null
 +++ b/arch/arm/dts/mt7981b-wirelesstag-zx7981poeq-ubootmod.dts
-@@ -0,0 +1,200 @@
+@@ -0,0 +1,190 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
 + * Copyright (C) 2024 Wireless-Tag
@@ -189,48 +189,38 @@
 +	leds {
 +		compatible = "gpio-leds";
 +
-+		power {
-+			label = "wt:power:blue";
++		run {
++			label = "wt:run:green";
 +			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
 +		};
 +
-+		wan {
-+			label = "wt:wan:blue";
-+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
-+		};
-+
-+		lan {
-+			label = "wt:lan:blue";
-+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
-+		};
-+
-+		4g_blue {
-+			label = "wt:4g:blue";
++		4g_high {
++			label = "wt:4g:high";
 +			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
 +		};
 +
-+		4g_yellow {
-+			label = "wt:4g:yellow";
++		4g_low {
++			label = "wt:4g:low";
 +			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
 +		};
 +
-+		5g_blue {
-+			label = "wt:5g:blue";
++		5g_high {
++			label = "wt:5g:high";
 +			gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
 +		};
 +
-+		5g_yellow {
-+			label = "wt:5g:yellow";
++		5g_low {
++			label = "wt:5g:low";
 +			gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
 +		};
 +
 +		sim1 {
-+			label = "wt:sim1:blue";
++			label = "wt:sim1:green";
 +			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
 +		};
 +
 +		sim2 {
-+			label = "wt:sim2:blue";
++			label = "wt:sim2:green";
 +			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
 +		};
 +	};

--- a/target/linux/mediatek/dts/mt7981b-wirelesstag-zx7981poeq-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7981b-wirelesstag-zx7981poeq-ubootmod.dts
@@ -40,70 +40,54 @@
 		compatible = "gpio-leds";
 
 		led-0 {
-			label = "wt:4g:blue";
-			color = <LED_COLOR_ID_BLUE>;
+			label = "wt:4g:high";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 12 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
 
 		led-1 {
-			label = "wt:sim2:blue";
-			color = <LED_COLOR_ID_BLUE>;
+			label = "wt:sim2:green";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 11 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
 
 		led-2 {
-			label = "wt:5g:blue";
-			color = <LED_COLOR_ID_BLUE>;
+			label = "wt:5g:high";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 9 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
 
 		led-3 {
-			label = "wt:4g:yellow";
-			color = <LED_COLOR_ID_YELLOW>;
+			label = "wt:4g:low";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
 
 		led-4 {
-			label = "wt:power:blue";
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_POWER;
+			label = "wt:run:green";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 4 GPIO_ACTIVE_HIGH>;
-			default-state = "on";
+			default-state = "off";
 		};
 
 		led-5 {
-			label = "wt:5g:yellow";
-			color = <LED_COLOR_ID_YELLOW>;
+			label = "wt:5g:low";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 10 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
 
 		led-6 {
-			label = "wt:sim1:blue";
-			color = <LED_COLOR_ID_BLUE>;
+			label = "wt:sim1:green";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 13 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
 
-		led-7 {
-			label = "wt:wan:blue";
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_WAN;
-			gpios = <&pio 22 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-		};
-
-		led-8 {
-			label = "wt:lan:blue";
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_LAN;
-			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-		};
 	};
 
 	gpio-export {

--- a/target/linux/mediatek/dts/mt7981b-wirelesstag-zx7981poeq.dts
+++ b/target/linux/mediatek/dts/mt7981b-wirelesstag-zx7981poeq.dts
@@ -37,70 +37,54 @@
 		compatible = "gpio-leds";
 
 		led-0 {
-			label = "wt:4g:blue";
-			color = <LED_COLOR_ID_BLUE>;
+			label = "wt:4g:high";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 12 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
 
 		led-1 {
-			label = "wt:sim2:blue";
-			color = <LED_COLOR_ID_BLUE>;
+			label = "wt:sim2:green";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 11 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
 
 		led-2 {
-			label = "wt:5g:blue";
-			color = <LED_COLOR_ID_BLUE>;
+			label = "wt:5g:high";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 9 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
 
 		led-3 {
-			label = "wt:4g:yellow";
-			color = <LED_COLOR_ID_YELLOW>;
+			label = "wt:4g:low";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
 
 		led-4 {
-			label = "wt:power:blue";
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_POWER;
+			label = "wt:run:green";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 4 GPIO_ACTIVE_HIGH>;
-			default-state = "on";
+			default-state = "off";
 		};
 
 		led-5 {
-			label = "wt:5g:yellow";
-			color = <LED_COLOR_ID_YELLOW>;
+			label = "wt:5g:low";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 10 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
 
 		led-6 {
-			label = "wt:sim1:blue";
-			color = <LED_COLOR_ID_BLUE>;
+			label = "wt:sim1:green";
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 13 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
 
-		led-7 {
-			label = "wt:wan:blue";
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_WAN;
-			gpios = <&pio 22 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-		};
-
-		led-8 {
-			label = "wt:lan:blue";
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_LAN;
-			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-		};
 	};
 
 	gpio-export {

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -172,6 +172,10 @@ zyxel,ex5601-t0-ubootmod)
 	ucidef_set_led_netdev "wifi-24g" "WIFI-2.4G" "green:wifi24g" "phy0-ap0" "link tx rx"
 	ucidef_set_led_netdev "wifi-5g" "WIFI-5G" "green:wifi5g" "phy1-ap0" "link tx rx"
 	;;
+wirelesstag,zx7981poeq|\
+wirelesstag,zx7981poeq-ubootmod)
+	ucidef_set_led_default "run" "RUN" "wt:run:green" "1"
+	;;
 *wirelesstag*)
 	ucidef_set_led_default "power" "POWER" "wt:power:blue" "1"
 	ucidef_set_led_netdev "wlan2g" "WLAN2G" "wt:wifi:blue" "ra0" "link tx rx"


### PR DESCRIPTION
Removed LED: lan, wan, wlan (not exisit)
Renamed LED: 4g/5g blue/yellow to 4g/5g low/high - power to run, change color to GREEN
Changed Color: sim1/sim2 from BLUE to GREEN